### PR TITLE
Update KB URLs

### DIFF
--- a/08-writing-technical-content.html.md
+++ b/08-writing-technical-content.html.md
@@ -3,7 +3,7 @@ title: Writing Technical Content
 layout: article
 ---
 
-At MailChimp, technical content is mostly written by the technical content team. It appears in the [Knowledge Base](http://kb.mailchimp.com), throughout the app, and in a few other locations. This section will lay out the guiding principles of technical content, discuss the main types of technical content, and outline the process of writing and editing technical articles.
+At MailChimp, technical content is mostly written by the technical content team. It appears in the [Knowledge Base](http://mailchimp.com/help/), throughout the app, and in a few other locations. This section will lay out the guiding principles of technical content, discuss the main types of technical content, and outline the process of writing and editing technical articles.
 
 ## Basics
 

--- a/09-writing-legal-content.html.md
+++ b/09-writing-legal-content.html.md
@@ -39,9 +39,9 @@ All of our public legal documents, and any changes to those documents, are draft
 
 We also publish guides and technical articles about legal concepts that may affect our users. Here are some examples:
 
-- [Terms of Use and anti-spam requirements](http://kb.mailchimp.com/accounts/compliance-tips/terms-of-use-and-anti-spam-requirements-for-campaigns)
-- [About the Canada anti-spam law](http://kb.mailchimp.com/accounts/compliance-tips/about-the-canada-anti-spam-law-casl)
-- [Stay compliant with CASL](http://kb.mailchimp.com/lists/managing-subscribers/stay-compliant-with-casl)
+- [Terms of Use and anti-spam requirements](https://mailchimp.com/help/terms-of-use-and-anti-spam-requirements/)
+- [About the Canada anti-spam law](https://mailchimp.com/help/about-the-canada-anti-spam-law-casl/)
+- [Stay compliant with CASL](https://mailchimp.com/help/stay-compliant-with-casl/)
 
 The legal team performs periodic reviews of all marketing and technical content to make sure all related links and information is up to date.
 

--- a/10-writing-email-newsletters.html.md
+++ b/10-writing-email-newsletters.html.md
@@ -47,7 +47,7 @@ Make the next step clear. Whether you’re asking people to buy something, read 
 
 #### Footer
 
-All campaigns follow [CAN-SPAM rules](http://kb.mailchimp.com/accounts/compliance-tips/terms-of-use-and-anti-spam-requirements-for-campaigns). Include an unsubscribe link, mailing address, and permission reminder in the footer of each newsletter.
+All campaigns follow [CAN-SPAM rules](https://mailchimp.com/help/terms-of-use-and-anti-spam-requirements/). Include an unsubscribe link, mailing address, and permission reminder in the footer of each newsletter.
 
 ### Consider your perspective
 

--- a/13-writing-for-translation.html.md
+++ b/13-writing-for-translation.html.md
@@ -9,7 +9,7 @@ We call the process of writing copy for translation “internationalization.” 
 
 ## Basics
 
-Our [Knowledge Base](http://kb.mailchimp.com) is available to all users in English, Spanish, and French. Sometimes other pieces of content will be translated as well.
+Our [Knowledge Base](http://mailchimp.com/help/) is available to all users in English, Spanish, and French. Sometimes other pieces of content will be translated as well.
 
 We try to write all of our content in standard, straightforward English that can be understood by users with limited English proficiency. It's much easier for a translator to clearly communicate ideas written in straightforward, uncomplicated sentences.
 


### PR DESCRIPTION
MailChimp recently migrated KB content from kb.mailchimp.com to mailchimp.com/help. 

This PR cleaning up any remaining kb.mailchimp.com references.