### PR TITLE
Update case of “MailChimp” to “Mailchimp”

### DIFF
--- a/00-index.html.md
+++ b/00-index.html.md
@@ -1,13 +1,13 @@
 ---
-title: Welcome to the MailChimp Content Style Guide
+title: Welcome to the Mailchimp Content Style Guide
 layout: article
 ---
 
-This style guide was created for MailChimp employees, but we hope it’s helpful for other content and communications teams too.
+This style guide was created for Mailchimp employees, but we hope it’s helpful for other content and communications teams too.
 
-## If you work at MailChimp
+## If you work at Mailchimp
 
-This is our company style guide. It helps us write clear and consistent content across teams and channels. Please use it as a reference when you’re writing for MailChimp.
+This is our company style guide. It helps us write clear and consistent content across teams and channels. Please use it as a reference when you’re writing for Mailchimp.
 
 This guide goes beyond basic grammar and style points. It’s not traditional in format or content. We break a number of grammar rules for clarity, practicality, or preference.
 
@@ -15,8 +15,8 @@ We’ve divided the guide by topic based on the types of content we publish, so 
 
 ## If you work at another organization
 
-We invite you to use and adapt this style guide as you see fit. It’s completely public and available under a Creative Commons Attribution-NonCommercial 4.0 International license. All we ask is that you credit MailChimp.
+We invite you to use and adapt this style guide as you see fit. It’s completely public and available under a Creative Commons Attribution-NonCommercial 4.0 International license. All we ask is that you credit Mailchimp.
 
 We welcome any feedback for improving the guide.
 
-[MailChimp Content Style Guide on GitHub](https://github.com/mailchimp/content-style-guide)
+[Mailchimp Content Style Guide on GitHub](https://github.com/mailchimp/content-style-guide)

--- a/02-voice-and-tone.html.md
+++ b/02-voice-and-tone.html.md
@@ -47,4 +47,4 @@ Here are a few key elements of writing Mailchimp’s voice. For more, see the [G
 
 ## A note about Freddie
 
-Freddie has been around in various forms since the company's beginning, and he captures the spirit of our brand’s personality. He smiles, winks, and sometimes high-fives, but he does not talk. Don't write in his voice. For more on how to use Freddie, see our [brand assets](http://mailchimp.com/about/brand-assets/).
+Freddie has been around in various forms since the company's beginning, and he captures the spirit of our brand’s personality. He smiles, winks, and sometimes high-fives, but he does not talk. Don't write in his voice. For more on how to use Freddie, see our [brand assets](https://mailchimp.com/about/brand-assets/).

--- a/03-writing-about-people.html.md
+++ b/03-writing-about-people.html.md
@@ -3,7 +3,7 @@ title: Writing About People
 layout: article
 ---
 
-We write the same way we build apps: with a person-first perspective. Whether you’re writing for an internal or external audience, it's important to write for and about other people in a way that’s compassionate, inclusive, and respectful. Being aware of the impact of your language will help make MailChimp a better place to work and a better steward of our values in the world. In this section we'll lay out some guidelines for writing about people with compassion, and share some resources for further learning.
+We write the same way we build apps: with a person-first perspective. Whether you’re writing for an internal or external audience, it's important to write for and about other people in a way that’s compassionate, inclusive, and respectful. Being aware of the impact of your language will help make Mailchimp a better place to work and a better steward of our values in the world. In this section we'll lay out some guidelines for writing about people with compassion, and share some resources for further learning.
 
 ### Age
 

--- a/04-grammar-and-mechanics.html.md
+++ b/04-grammar-and-mechanics.html.md
@@ -150,7 +150,7 @@ Use a hyphen between times to indicate a time period. 
 
 - 7am-10:30pm
 
-Specify time zones when writing about an event or something else people would need to schedule. Since MailChimp is in Atlanta, we default to ET.
+Specify time zones when writing about an event or something else people would need to schedule. Since Mailchimp is in Atlanta, we default to ET.
 
 Abbreviate time zones within the continental United States as follows:
 
@@ -298,7 +298,7 @@ For more on writing about gender, see [Writing about people](/03-writing-about-p
 
 When quoting someone in a blog post or other publication, use the present tense.
 
-- “Using MailChimp has helped our business grow,” says Jamie Smith.
+- “Using Mailchimp has helped our business grow,” says Jamie Smith.
 
 #### Names and titles
 
@@ -337,18 +337,18 @@ Capitalize the names of websites and web publications. Don’t italicize.
 
 Avoid spelling out URLs, but when you need to, leave off the http://www.
 
-#### Writing about MailChimp
+#### Writing about Mailchimp
 
-Our company's legal entity name is "The Rocket Science Group, LLC." Our trade name is "MailChimp." Use "The Rocket Science Group, LLC" only when writing legal documents or contracts. Otherwise, use "MailChimp."
+Our company's legal entity name is "The Rocket Science Group, LLC." Our trade name is "Mailchimp." Use "The Rocket Science Group, LLC" only when writing legal documents or contracts. Otherwise, use "Mailchimp."
 
-Always capitalize the first “M” and the “C” in MailChimp.
+Always capitalize the first “M” and lowercase the “c” in Mailchimp.
 
-Refer to MailChimp as “we,” not “it.”
+Refer to Mailchimp as “we,” not “it.”
 
-Capitalize the proper names of MailChimp products, features, pages, and tools. When referencing non-trademarked products like Pro, Snap, and Automation, include "MailChimp" in the name on first mention.
+Capitalize the proper names of Mailchimp products, features, pages, and tools. When referencing non-trademarked products like Pro, Snap, and Automation, include "Mailchimp" in the name on first mention.
 
-- MailChimp Pro
-- MailChimp Snap
+- Mailchimp Pro
+- Mailchimp Snap
 - Look What You Can Do
 
 #### Writing about other companies
@@ -365,7 +365,7 @@ Refer to a company or product as “it” (not “they”).
 
 Write in plain English. If you need to use a technical term, briefly define it so everyone can understand.
 
-- MailChimp's ops team is constantly scaling our servers to make sure our users have a great experience with our products. One way we do this is with shards, or partitions, that help us better horizontally scale our database infrastructure.
+- Mailchimp's ops team is constantly scaling our servers to make sure our users have a great experience with our products. One way we do this is with shards, or partitions, that help us better horizontally scale our database infrastructure.
 
 ### Text formatting
 
@@ -374,7 +374,7 @@ Use italics to indicate the title of a long work (like a book, movie, or album) 
 - *Dunston Checks In*
 - Brandon *really* loves *Dunston Checks In*.
 
-Use italics when citing an example of an in-app MailChimp element, or referencing button and navigation labels in step-by-step instructions:
+Use italics when citing an example of an in-app Mailchimp element, or referencing button and navigation labels in step-by-step instructions:
 
 - When you're all done, click *Send*.
 - The familiar A/B testing variables—*Subject line*, *From name*, and *Send time*—have now been joined by *Content*, and up to 3 combinations of a single variable can now be tested at once.

--- a/07-writing-blog-posts.html.md
+++ b/07-writing-blog-posts.html.md
@@ -3,20 +3,20 @@ title: Writing Blog Posts
 layout: article
 ---
 
-MailChimp blog posts are written by people from all over the company, not just those with “writer” in their job titles. We love having experts from around the office blog about their work. The person most familiar with the subject is in the best position to convey it, and the writers on the marketing team can help with brainstorming and editing as needed.
+Mailchimp blog posts are written by people from all over the company, not just those with “writer” in their job titles. We love having experts from around the office blog about their work. The person most familiar with the subject is in the best position to convey it, and the writers on the marketing team can help with brainstorming and editing as needed.
 
-We have several MailChimp blogs, including ones written by our [design](http://creative.mailchimp.com), [engineering](http://devs.mailchimp.com/blog/), and [technical content](http://docmakers.mailchimp.com) teams. This section will focus on the main [MailChimp marketing blog](http://blog.mailchimp.com), but the guidelines apply to the other channels, too.
+We have several Mailchimp blogs, including ones written by our [design](http://creative.mailchimp.com), [engineering](http://devs.mailchimp.com/blog/), and [technical content](http://docmakers.mailchimp.com) teams. This section will focus on the main [Mailchimp marketing blog](http://blog.mailchimp.com), but the guidelines apply to the other channels, too.
 
 ## Basics
 
-We update the main MailChimp blog a couple times every week. We generally publish:
+We update the main Mailchimp blog a couple times every week. We generally publish:
 
 * Feature, release, and integration announcements
-* MailChimp user case studies
+* Mailchimp user case studies
 * Tips and tricks for small businesses
-* Examples of how we use MailChimp’s features in our own marketing
+* Examples of how we use Mailchimp’s features in our own marketing
 
-We publish blog posts that explain the “why” behind the work we do at MailChimp. We want to show people that we're an industry leader with the best products, and we use our blog to tell the stories behind those products.
+We publish blog posts that explain the “why” behind the work we do at Mailchimp. We want to show people that we're an industry leader with the best products, and we use our blog to tell the stories behind those products.
 
 ## Guidelines
 
@@ -26,19 +26,19 @@ When writing for the blog, follow the style points outlined in the [Voice and to
 This isn’t a term paper, so there’s no need to be stuffy. Drop some knowledge while casually engaging your readers with conversational language.
 
 ### Be specific
-If you're writing about data, put the numbers in context. If you're writing about a MailChimp user, give the reader plenty of information about the company's stage, workflow, results, and values.
+If you're writing about data, put the numbers in context. If you're writing about a Mailchimp user, give the reader plenty of information about the company's stage, workflow, results, and values.
 
 ### Get to the point
 Get to the important stuff right away, and don’t bury the kicker. Blog posts should be scannable and easy to digest. Break up your paragraphs into short chunks of three or four sentences, and use subheads. Our users are busy, and we should always keep that in mind.
 
 ### Link it up
-Feel free to link away from MailChimp if it helps you explain something.
+Feel free to link away from Mailchimp if it helps you explain something.
 
 ### Make 'em LOL
-MailChimp is a fun company, and we want our blog to reflect this. Feel free to throw in a joke here and there, or link out to a funny GIF or YouTube video when appropriate. Just don't overdo it.
+Mailchimp is a fun company, and we want our blog to reflect this. Feel free to throw in a joke here and there, or link out to a funny GIF or YouTube video when appropriate. Just don't overdo it.
 
 ### Use tags and keywords
 In WordPress, add keywords that apply to your article. Look through existing posts for common tags. If you’re not sure if a word should be a tag, it probably shouldn’t.
 
 ### Use pictures
-Include images in your blog posts when it makes sense. If you’re explaining how to use MailChimp, include screenshots to illustrate your point. Make sure to use alt text.
+Include images in your blog posts when it makes sense. If you’re explaining how to use Mailchimp, include screenshots to illustrate your point. Make sure to use alt text.

--- a/08-writing-technical-content.html.md
+++ b/08-writing-technical-content.html.md
@@ -3,7 +3,7 @@ title: Writing Technical Content
 layout: article
 ---
 
-At MailChimp, technical content is mostly written by the technical content team. It appears in the [Knowledge Base](http://mailchimp.com/help/), throughout the app, and in a few other locations. This section will lay out the guiding principles of technical content, discuss the main types of technical content, and outline the process of writing and editing technical articles.
+At Mailchimp, technical content is mostly written by the technical content team. It appears in the [Knowledge Base](http://mailchimp.com/help/), throughout the app, and in a few other locations. This section will lay out the guiding principles of technical content, discuss the main types of technical content, and outline the process of writing and editing technical articles.
 
 ## Basics
 
@@ -19,11 +19,11 @@ We don’t want to overload a reader with unnecessary information, choices to ma
 
 ## Types of technical content
 
-Technical content articles vary in target audience, goal, and tone. MailChimp technical content is built from 8 templates, which serve different purposes and readers.
+Technical content articles vary in target audience, goal, and tone. Mailchimp technical content is built from 8 templates, which serve different purposes and readers.
 
 | **Article Template** | **User Type**                  | **Goal**                                                                        |
 | -------------------- | ----------------------         | ------------------------------------------------------------------------------- |
-| Best Practices       | all                            | **Context.** Make connections between MailChimp and email marketing as a whole. |
+| Best Practices       | all                            | **Context.** Make connections between Mailchimp and email marketing as a whole. |
 | Cheat Sheet          | intermediate, advanced         | **Reference.** Include all available scenarios.                                 |
 | Getting Started      | prospective, new               | **Overview.** Include brief outline of topic, uses, benefits, and related topics. Use links to best practices, cheat sheets, and feature overviews. |
 | Policy               | all                            | **Education.** Provide digestible information about critical legal policies and procedures. |
@@ -36,7 +36,7 @@ Technical content articles vary in target audience, goal, and tone. MailChimp te
 
 ### Drafting technical content
 
-Before you begin writing a new article, reach out to a subject matter expert at MailChimp (like an engineer, tester, designer, researcher, or technical support advisor) to get as much information as possible. You may only use a small portion of what you learn, but it helps to have more information than you need to decide where to focus your article.
+Before you begin writing a new article, reach out to a subject matter expert at Mailchimp (like an engineer, tester, designer, researcher, or technical support advisor) to get as much information as possible. You may only use a small portion of what you learn, but it helps to have more information than you need to decide where to focus your article.
 
 Consider how many articles are needed and what article types will best describe a new feature or tasks to the user.
 
@@ -80,7 +80,7 @@ We edit technical content based on three goals:
 
 **Consistency**
 
-- Use the labels and terminology used in the MailChimp app.
+- Use the labels and terminology used in the Mailchimp app.
 - Use specific, active verbs for certain tasks.
 - Choose basic words and phrases to facilitate consistency across translated content.
 
@@ -97,9 +97,9 @@ Technical content uses organization, capitalization, and other formatting to hel
 
 #### Capitalization
 
-Capitalize proper names of MailChimp products, features, pages, tools, and team names when directly mentioned. In step-by-step instructions, capitalize and italicize navigation and button labels as they appear in the app.
+Capitalize proper names of Mailchimp products, features, pages, tools, and team names when directly mentioned. In step-by-step instructions, capitalize and italicize navigation and button labels as they appear in the app.
 
-- MailChimp, Mandrill
+- Mailchimp, Mandrill
 - Campaigns page, Lists page
 - Compliance Team, Billing Team
 - Navigate to the *Automation* page.

--- a/09-writing-legal-content.html.md
+++ b/09-writing-legal-content.html.md
@@ -3,15 +3,15 @@ title: Writing Legal Content
 layout: article
 ---
 
-MailChimp publishes many kinds of legal content to protect ourselves and our users around the world. Most of our legal content is written by the legal department with help from the communications team. This section gives a general overview of the types of legal content we publish and how those documents are written.
+Mailchimp publishes many kinds of legal content to protect ourselves and our users around the world. Most of our legal content is written by the legal department with help from the communications team. This section gives a general overview of the types of legal content we publish and how those documents are written.
 
 For information about laws that apply to non-legal content, see the [Copyright and trademark](/15-copyright-and-trademarks.html.md) section.
 
 ## Basics
 
-The way we write, review, and publish legal content is different than how we do many other kinds of writing at MailChimp. The most important difference is that all legal content either starts with or passes through the legal team.
+The way we write, review, and publish legal content is different than how we do many other kinds of writing at Mailchimp. The most important difference is that all legal content either starts with or passes through the legal team.
 
-But that doesn't mean legal content has to be difficult to read. We try to present our legal information in the most pleasant way possible. Our goals for MailChimp's legal content are:
+But that doesn't mean legal content has to be difficult to read. We try to present our legal information in the most pleasant way possible. Our goals for Mailchimp's legal content are:
 
 * **Accuracy.** Our first and foremost concern is that we present the correct information in a truthful way.
 * **Clarity.** We try to avoid legal jargon and overly formal wording. Our users need to understand the agreement they’re making with us.
@@ -31,7 +31,7 @@ We keep these in one place on our [legal page](http://mailchimp.com/legal/):
 * [API use policy](http://mailchimp.com/legal/api_use/)
 * [Copyright policy](http://mailchimp.com/legal/copyright/)
 
-These policies apply to all of MailChimp’s users. The legal and communication teams work together to make them as transparent and easy to read as possible. When someone signs up to use MailChimp, they must agree to all of those terms.
+These policies apply to all of Mailchimp’s users. The legal and communication teams work together to make them as transparent and easy to read as possible. When someone signs up to use Mailchimp, they must agree to all of those terms.
 
 All of our public legal documents, and any changes to those documents, are drafted by our in-house legal team. When new legal documents are published or edited, we notify all our users of the updates and provide a window for them to object before the new terms go into effect.
 
@@ -83,7 +83,7 @@ Some companies have complicated terms and write plain-language summaries so peop
 
 Using plain language for the terms you define up front can make legal documents easier to read. You’ve probably read contracts that say something like “The Corporation” or “The User” throughout, instead of “we” (meaning the company) and “you” (meaning the user who is agreeing to the terms). There’s a quick fix for that. At the beginning of the document, say something like:
 
-- MailChimp is owned and operated by The Rocket Science Group, LLC d/b/a MailChimp, a Georgia limited liability corporation (“MailChimp,” “we,” or “us”). As a user of the Service or a representative of an entity that’s a user of the Service, you're a “Member” according to this agreement (or “you”).
+- Mailchimp is owned and operated by The Rocket Science Group, LLC d/b/a Mailchimp, a Georgia limited liability corporation (“Mailchimp,” “we,” or “us”). As a user of the Service or a representative of an entity that’s a user of the Service, you're a “Member” according to this agreement (or “you”).
 
 After that, you’re free to use “we,” “us,” “you,” and “your” throughout the rest of the agreement. That simple change makes the document much friendlier to read.
 
@@ -93,4 +93,4 @@ We use contractions in many of our legal documents, which makes them sound more 
 
 #### Never offer legal advice
 
-While we want to inform our users about legal issues related to their use of MailChimp, we can’t offer them legal advice. Sometimes it’s a fine line. The legal department will check for this in their content review.
+While we want to inform our users about legal issues related to their use of Mailchimp, we can’t offer them legal advice. Sometimes it’s a fine line. The legal department will check for this in their content review.

--- a/10-writing-email-newsletters.html.md
+++ b/10-writing-email-newsletters.html.md
@@ -7,12 +7,12 @@ We send a lot of email ourselves, and we follow our own best practices to set an
 
 ## Basics
 
-Our email newsletters help empower and inform MailChimp users. Here are the most common types of content we send by email:
+Our email newsletters help empower and inform Mailchimp users. Here are the most common types of content we send by email:
 
 - Product and feature announcements
 - Tips for getting the most out of existing products and features
 - Regular monthly newsletters
-- Automated series (Getting Started with MailChimp)
+- Automated series (Getting Started with Mailchimp)
 - Event invitations and information about online courses
 - System alerts about changes to functionality or scheduled maintenance
 - Internal newsletters
@@ -51,7 +51,7 @@ All campaigns follow [CAN-SPAM rules](https://mailchimp.com/help/terms-of-use-an
 
 ### Consider your perspective
 
-When sending an email newsletter from MailChimp, use the 3rd person “we.” When sending a newsletter as an individual, use the 1st person.
+When sending an email newsletter from Mailchimp, use the 3rd person “we.” When sending a newsletter as an individual, use the 1st person.
 
 ### Use a hierarchy
 Most readers will be scanning your emails or viewing them on a small screen. Put the most important information first.

--- a/11-writing-for-social-media.html.md
+++ b/11-writing-for-social-media.html.md
@@ -3,18 +3,18 @@ title: Writing for Social Media
 layout: article
 ---
 
-We use social media to build relationships with MailChimp users and share all the cool stuff we do. But it also creates opportunities to say the wrong thing, put off customers, and damage our brand. So we’re careful and deliberate in what we post to our social channels. This section lays out how we strike that delicate balance.
+We use social media to build relationships with Mailchimp users and share all the cool stuff we do. But it also creates opportunities to say the wrong thing, put off customers, and damage our brand. So we’re careful and deliberate in what we post to our social channels. This section lays out how we strike that delicate balance.
 
 ## Basics
 
-MailChimp has a presence on most major social media platforms. Here are our most active accounts and what we usually post on each:
+Mailchimp has a presence on most major social media platforms. Here are our most active accounts and what we usually post on each:
 
 - [Twitter](http://twitter.com/mailchimp): Product news, brand marketing, events, media mentions, evergreen content, “we’re hiring!” posts
 - [Facebook](http://facebook.com/mailchimp): Product news, brand marketing, events, media mentions, evergreen content,  “we’re hiring!” posts
 - [LinkedIn](http://linkedin.com/company/mailchimp): Product news, recruiting content, media mentions, evergreen content
-- [Instagram](http://instagram.com/mailchimp): Design outtakes, cool office visitors, life at MailChimp, cool stuff we made
+- [Instagram](http://instagram.com/mailchimp): Design outtakes, cool office visitors, life at Mailchimp, cool stuff we made
 
-These channels are all managed by the marketing team. We also have a few team-specific accounts on Twitter, Tumblr, Dribbble, and other platforms. The guidelines in this section apply to all of MailChimp's channels.
+These channels are all managed by the marketing team. We also have a few team-specific accounts on Twitter, Tumblr, Dribbble, and other platforms. The guidelines in this section apply to all of Mailchimp's channels.
 
 ## Guidelines
 
@@ -32,19 +32,19 @@ To write short, simplify your ideas or reduce the amount of information you’re
 
 ### Engagement
 
-Do your best to adhere to MailChimp style guidelines when you’re using our social media channels to correspond with users. Use correct grammar and punctuation—and avoid excessive exclamation points.
+Do your best to adhere to Mailchimp style guidelines when you’re using our social media channels to correspond with users. Use correct grammar and punctuation—and avoid excessive exclamation points.
 
 When appropriate, you can tag the subject of your post on Twitter or Facebook. But avoid directly tweeting at or otherwise publicly tagging a post subject with messages like, “Hey, we wrote about you!” Never ask for retweets, likes, or favorites.
 
-- Yes: [“We talked with @lauraolin about turning her awesome emails into a book. http://blog.mailchimp.com/how-laura-olins-emails-got-her-freelance-work-and-a-book-deal”](https://twitter.com/MailChimp/status/593075130336686080)
+- Yes: [“We talked with @lauraolin about turning her awesome emails into a book. http://blog.mailchimp.com/how-laura-olins-emails-got-her-freelance-work-and-a-book-deal”](https://twitter.com/Mailchimp/status/593075130336686080)
 - No: “Hey @lauraolin, can you RT this post we wrote about you? http://blog.mailchimp.com/how-laura-olins-emails-got-her-freelance-work-and-a-book-deal”
 
 ### Hashtags
 
-We employ hashtags rarely and deliberately. We may use them to promote an event or connect with users at a conference. Do not use current event or trending hashtags to promote MailChimp.
+We employ hashtags rarely and deliberately. We may use them to promote an event or connect with users at a conference. Do not use current event or trending hashtags to promote Mailchimp.
 
 ### Trending topics
 
-Do not use social media to comment on trending topics or current events that are unrelated to MailChimp.
+Do not use social media to comment on trending topics or current events that are unrelated to Mailchimp.
 
-Be aware of what’s going on in the news when you're publishing social content for MailChimp. During major breaking news events, we turn off all promoted and scheduled social posts.
+Be aware of what’s going on in the news when you're publishing social content for Mailchimp. During major breaking news events, we turn off all promoted and scheduled social posts.

--- a/13-writing-for-translation.html.md
+++ b/13-writing-for-translation.html.md
@@ -3,7 +3,7 @@ title: Writing for Translation
 layout: article
 ---
 
-MailChimp serves millions of users in hundreds of countries and territories, not just the United States. As our user base grows, it becomes more and more important that our content is accessible to people around the world.
+Mailchimp serves millions of users in hundreds of countries and territories, not just the United States. As our user base grows, it becomes more and more important that our content is accessible to people around the world.
 
 We call the process of writing copy for translation “internationalization.” This section will address things you can do to help international audiences, including translators, better comprehend your text.
 
@@ -27,7 +27,7 @@ When writing for international audiences, we generally follow what's outlined in
 
 ### Consider cultural differences
 
-MailChimp’s voice is conversational and informal. However, in some cultures, informal text may be considered offensive. Check with your translator to see if this is the case for the particular language you’re writing for.
+Mailchimp’s voice is conversational and informal. However, in some cultures, informal text may be considered offensive. Check with your translator to see if this is the case for the particular language you’re writing for.
 
 The translation company should give the option to translate in a formal or informal tone, if the language allows for it. (For example, in Spanish, it is possible to write informally where tú = you or formally where usted = you.)
 
@@ -44,23 +44,23 @@ Keep your copy brief, but don’t sacrifice clarity for brevity. You may need to
 
 #### Repeat helping verbs belonging to multiple verbs
 
-  - Yes: MailChimp can send your campaign on the fly or can schedule your campaign to go out at a set time.
-  - No: MailChimp can send your campaign on the fly or schedule your campaign to go out at a set time.
+  - Yes: Mailchimp can send your campaign on the fly or can schedule your campaign to go out at a set time.
+  - No: Mailchimp can send your campaign on the fly or schedule your campaign to go out at a set time.
 
 #### Repeat subjects and verbs
 
-  - Yes: Mandrill sends transactional emails, but MailChimp does not.
-  - No: Mandrill sends transactional emails, but not MailChimp.
+  - Yes: Mandrill sends transactional emails, but Mailchimp does not.
+  - No: Mandrill sends transactional emails, but not Mailchimp.
 
 #### Repeat markers in a list or series
 
-  - Yes: Use MailChimp to send email campaigns, to manage your mailing lists, and to integrate with other applications.
-  - No: Use MailChimp to send email campaigns, manage your mailing lists, and integrate with other applications.
+  - Yes: Use Mailchimp to send email campaigns, to manage your mailing lists, and to integrate with other applications.
+  - No: Use Mailchimp to send email campaigns, manage your mailing lists, and integrate with other applications.
 
 #### Leave in words like “then,” “a,” “the,” “to,” and “that," even if you think they could be cut
 
-- Yes: If there is not a list set up in your MailChimp account, then you’ll need to create a list before sending your first campaign.
-- No: If there is not a list set up in your MailChimp account, you’ll need to create a list before sending your first campaign.
+- Yes: If there is not a list set up in your Mailchimp account, then you’ll need to create a list before sending your first campaign.
+- No: If there is not a list set up in your Mailchimp account, you’ll need to create a list before sending your first campaign.
 - Yes: When sending a campaign, it is necessary to have a “From:” name, a “From:” address, and a subject line.
 - No: When sending a campaign, it is necessary to have a “From:” name, “From:” address, and subject line.
 - Yes: Be sure that you are truly ready to send your campaign before clicking the “Send Now” button.
@@ -72,8 +72,8 @@ Many words, parts of speech, and grammar mechanics we don’t think twice about 
 
 #### Avoid unclear pronoun references
 
-- Yes: Many believe that buying a list of email addresses and sending to the list through MailChimp is OK. Such action can actually cause high rates of abuse, bounces, and unsubscribes. Purchasing a list and sending to it may cause your account to be suspended.
-- No: Many believe that buying a list of email addresses and sending to the list through MailChimp is okay. This can actually cause high rates of abuse, bounces, and unsubscribes. It can ultimately cause your account to be suspended.
+- Yes: Many believe that buying a list of email addresses and sending to the list through Mailchimp is OK. Such action can actually cause high rates of abuse, bounces, and unsubscribes. Purchasing a list and sending to it may cause your account to be suspended.
+- No: Many believe that buying a list of email addresses and sending to the list through Mailchimp is okay. This can actually cause high rates of abuse, bounces, and unsubscribes. It can ultimately cause your account to be suspended.
 
 #### Avoid -ing words
 

--- a/14-creating-structured-content.html.md
+++ b/14-creating-structured-content.html.md
@@ -3,7 +3,7 @@ title: Creating Structured Content
 layout: article
 ---
 
-At MailChimp, we write 2 kinds of content: structured and unstructured. Most of our technical and educational documents are structured, following standardized content templates. These templates make both writing and reading easier. They also help future-proof our documents, making it easier for developers to come in later and add semantic data to make the work reusable outside of where it was originally published. 
+At Mailchimp, we write 2 kinds of content: structured and unstructured. Most of our technical and educational documents are structured, following standardized content templates. These templates make both writing and reading easier. They also help future-proof our documents, making it easier for developers to come in later and add semantic data to make the work reusable outside of where it was originally published. 
 
 This section lays out when to use a structured content template and how to create a template of your own.
 
@@ -18,7 +18,7 @@ Consider using a template if:
 - Writers need to be able to create it quickly
 - You want to encourage repeat visits and familiarity with your content
 
-All educational content at MailChimp relies heavily on content templates. We use templates for Knowledge Base articles, Integration Directory descriptions, marketing guides, and more.
+All educational content at Mailchimp relies heavily on content templates. We use templates for Knowledge Base articles, Integration Directory descriptions, marketing guides, and more.
 
 Find all of our structured content templates in the [Resources section](/18-resources.html.md).
 

--- a/15-copyright-and-trademarks.html.md
+++ b/15-copyright-and-trademarks.html.md
@@ -13,13 +13,13 @@ Copyright protection begins when the work is first created and it doesn’t requ
 
 Copyright notice on the work is not required but it *is* recommended, since it cuts off a defense of [innocent infringement](https://www.law.cornell.edu/uscode/text/17/401).
 
-## Copyright at MailChimp
+## Copyright at Mailchimp
 
-Copyright law applies to nearly every piece of content we create at MailChimp, from our website to our blog posts to the gifts we make for our users. We display proper—and prominent—copyright notice on our website site and any other content we produce.
+Copyright law applies to nearly every piece of content we create at Mailchimp, from our website to our blog posts to the gifts we make for our users. We display proper—and prominent—copyright notice on our website site and any other content we produce.
 
-At minimum, these copyright notices read, “&copy; [YEAR] MailChimp.”
+At minimum, these copyright notices read, “&copy; [YEAR] Mailchimp.”
 
-At the bottom of every page of our website, we also include a longer notice to make it clear that all rights are reserved and our marks are registered: “&copy; 2001-2015 All Rights Reserved. MailChimp<sup>&reg;</sup> is a registered trademark of The Rocket Science Group.”
+At the bottom of every page of our website, we also include a longer notice to make it clear that all rights are reserved and our marks are registered: “&copy; 2001-2015 All Rights Reserved. Mailchimp<sup>&reg;</sup> is a registered trademark of The Rocket Science Group.”
 
 ### Other creators’ copyrights
 
@@ -36,21 +36,21 @@ A copyright license spells out these terms:
 
 A common license will read something like this:
 
-“You grant MailChimp a perpetual, worldwide, non-exclusive, royalty free license to display, distribute, and publish the Work in our marketing in any medium now known or later developed.”
+“You grant Mailchimp a perpetual, worldwide, non-exclusive, royalty free license to display, distribute, and publish the Work in our marketing in any medium now known or later developed.”
 
-If you need to get a copyright license for work at MailChimp or if someone outside of MailChimp asks to use our copyrighted work, please contact the legal team.
+If you need to get a copyright license for work at Mailchimp or if someone outside of Mailchimp asks to use our copyrighted work, please contact the legal team.
 
 ### Social media and copyright
 
 This is an area where the letter of the law and common practice sometimes differ.
 
-Social media posts often include copyrighted elements like pictures, GIFs, or pieces of writing. If you’re using a copyrighted element in a commercial manner on social media, you should request permission from the copyright holder. Since MailChimp is a company, we defer to the position that our use will be perceived as commercial. But if you’re using it in a more informative or commentary way, like sharing a meme to indicate how you feel about a news story, you may not need to request permission.
+Social media posts often include copyrighted elements like pictures, GIFs, or pieces of writing. If you’re using a copyrighted element in a commercial manner on social media, you should request permission from the copyright holder. Since Mailchimp is a company, we defer to the position that our use will be perceived as commercial. But if you’re using it in a more informative or commentary way, like sharing a meme to indicate how you feel about a news story, you may not need to request permission.
 
 Regardless, you should always link to the source of the copyrighted element you’re using, and never make it look like you created work that belongs to someone else.
 
 ### Image use and copyright
 
-MailChimp almost always uses original images in our blog posts. If you use an image, photo, or other design element made by someone outside MailChimp, get permission first. Once you have permission, always give the copyright owner credit and link back to the original source.
+Mailchimp almost always uses original images in our blog posts. If you use an image, photo, or other design element made by someone outside Mailchimp, get permission first. Once you have permission, always give the copyright owner credit and link back to the original source.
 
 Images retrieved via Google image search are not licensed for fair use, but many images are available under license through stock photo websites, or open for use under a Creative Commons license. Flickr has a great search feature for images available under Creative Commons licenses.
 
@@ -60,7 +60,7 @@ Images retrieved via Google image search are not licensed for fair use, but many
 
 Instead of the standard “all rights reserved,” some creators choose to make their work available for public use with different levels of attribution required. That’s what we’ve done with this style guide. Find a breakdown of licenses on the [Creative Commons website](https://creativecommons.org/licenses/).
 
-Please check with MailChimp’s legal team before making something you created here available under a Creative Commons license. We love to share our work, but we use these licenses sparingly, because we have to protect our intellectual property and trade secrets.
+Please check with Mailchimp’s legal team before making something you created here available under a Creative Commons license. We love to share our work, but we use these licenses sparingly, because we have to protect our intellectual property and trade secrets.
 
 ### Trademarks
 
@@ -74,7 +74,7 @@ To be protectable, a trademark needs a distinctive element. There’s a “spect
 - **Descriptive marks**, where the word's dictionary meaning aligns with the goods or services offered, like Mr. Plumber or Lektronic, are not protectable unless they develop a secondary meaning. That means a consumer would immediately associate the mark with only that good or service. This can be hard to prove, so it's best to avoid descriptive marks when possible.
 - **Generic terms**, or the common name for a product or service, are not protectable.
 
-We usually classify MailChimp as a suggestive mark, but it could also be considered fanciful.
+We usually classify Mailchimp as a suggestive mark, but it could also be considered fanciful.
 
 A trademark is only valid for as long as it indicates the source of that good or service, so we have to be very careful about how our marks are used. We send out cease and desist letters sometimes, because even the friendliest companies have to protect their trademarks. If a trademark is properly protected, it can last forever and may be a company's most valuable asset.
 
@@ -91,19 +91,19 @@ Here are the various trademark symbols and when to use them:
 
 The trademark symbol should appear as close to the mark as possible.
 
-Here’s how to indicate MailChimp’s trademark:
+Here’s how to indicate Mailchimp’s trademark:
 
-- Include the &reg; symbol in the upper right-hand corner, above the word: MailChimp<sup>&reg;</sup> this use is preferable.
-- Include the &reg; symbol in the lower right-hand corner, below the word: MailChimp<sub>&reg;</sub>
+- Include the &reg; symbol in the upper right-hand corner, above the word: Mailchimp<sup>&reg;</sup> this use is preferable.
+- Include the &reg; symbol in the lower right-hand corner, below the word: Mailchimp<sub>&reg;</sub>
 
 Marks are also sometimes indicated by using all caps: MAILCHIMP
 
 Our trademarks should be properly noted the first time they’re used in a press release or article, or anywhere else our trademark and copyright notice does not appear.
 
-## Registering trademarks at MailChimp
+## Registering trademarks at Mailchimp
 
 We register all of our trademarks. Before we decide to use a name for a product, we perform a trademark search to make sure there aren’t any confusingly similar trademarks already in use.
 
 For the most part, our trademarks are “suggestive marks,” which mean the name suggests at some element of the goods or services represented.
 
-If you’re working on a new product at MailChimp, submit name possibilities to the legal team so they can get a head start on the trademark search. Even if you haven’t used the name yet, we can go ahead and file an Intent to Use application.
+If you’re working on a new product at Mailchimp, submit name possibilities to the legal team so they can get a head start on the trademark search. Even if you haven’t used the name yet, we can go ahead and file an Intent to Use application.

--- a/17-further-reading.html.md
+++ b/17-further-reading.html.md
@@ -23,4 +23,4 @@ If you’re working on your own style guide, these resources were helpful to us:
 
 Want to adapt our guide to use at your own organization?
 
-[MailChimp Style Guide on GitHub](https://github.com/mailchimp/style-guide)
+[Mailchimp Style Guide on GitHub](https://github.com/mailchimp/style-guide)

--- a/18-tldr.html.md
+++ b/18-tldr.html.md
@@ -3,7 +3,7 @@ title: TL;DR
 layout: article
 ---
 
-The MailChimp Content Style Guide goes into depth on many subjects. It may be more information than you need. Here are the most important things to know.
+The Mailchimp Content Style Guide goes into depth on many subjects. It may be more information than you need. Here are the most important things to know.
 
 ## Principles
 
@@ -16,7 +16,7 @@ Good content is:
 
 ## Voice and tone
 
-MailChimp’s voice is:
+Mailchimp’s voice is:
 
 * Human
 * Familiar
@@ -27,11 +27,11 @@ Our tone changes depending on the situation, but it's generally informal. We hav
 
 Our priorities are to educate our users about our products without patronizing or confusing them, so they can get their work done and get on with their lives.
 
-Related resource: The MailChimp [Voice and Tone guide](http://voiceandtone.com/).
+Related resource: The Mailchimp [Voice and Tone guide](http://voiceandtone.com/).
 
 ## Writing about people
 
-We write and build apps with a person-first perspective. Being aware of the impact of your language will help make MailChimp a better place to work and a better steward of our values in the world.
+We write and build apps with a person-first perspective. Being aware of the impact of your language will help make Mailchimp a better place to work and a better steward of our values in the world.
 
 - Don’t reference age or disability unless it’s relevant to what you’re writing.
 - Avoid gendered language and use the singular “they.”

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for helping us improve the MailChimp Content Style Guide.
+Thanks for helping us improve the Mailchimp Content Style Guide.
 
 ## Ways to Contribute
 
@@ -12,4 +12,4 @@ We welcome your feedback. To send us your suggestions, submit an issue in GitHub
 
 ### Creating Your Own Style Guide
 
-Feel free to fork the MailChimp Content Style Guide to make your own. It’s available under a Creative Commons Attribution-NonCommercial 4.0 International License. We can’t wait to see what you do with it!
+Feel free to fork the Mailchimp Content Style Guide to make your own. It’s available under a Creative Commons Attribution-NonCommercial 4.0 International License. We can’t wait to see what you do with it!

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
-# Welcome to the MailChimp Content Style Guide
+# Welcome to the Mailchimp Content Style Guide
 
-This style guide is primarily for MailChimp employees, but we hope it’s helpful to other organizations as well.
+This style guide is primarily for Mailchimp employees, but we hope it’s helpful to other organizations as well.
 
-If you're looking for the MailChimp Content Style Guide website, visit [styleguide.mailchimp.com](http://styleguide.mailchimp.com).
+If you're looking for the Mailchimp Content Style Guide website, visit [styleguide.mailchimp.com](http://styleguide.mailchimp.com).
 
-Whether or not you work at MailChimp, we welcome your thoughts and suggestions. To learn more about sending us feedback or adapting this guide to create your own, see the Contributing file.
+Whether or not you work at Mailchimp, we welcome your thoughts and suggestions. To learn more about sending us feedback or adapting this guide to create your own, see the Contributing file.
 
 ## Using the Guide
 


### PR DESCRIPTION
This reflects our new brand guidelines. In summary the reasoning:

> We have also made the "c" in Mailchimp lowercased. We used to be an email
> company, but now we do so much more than that, from automations and ads to
> landing pages and postcards. Our name now stands for more than its component
> parts. To help with that mental shift, we now write it as a single word with
> a capital M: Mailchimp.